### PR TITLE
Minor spatial patch

### DIFF
--- a/R/general_gd.R
+++ b/R/general_gd.R
@@ -38,6 +38,8 @@ future::plan() should be used to setup parallelization instead (see package vign
   # run sliding window calculations
   # currently, terra uses a C++ pointer which means SpatRasters cannot be directly passed to nodes on a computer cluster
   # instead of saving the raster layer to a file, I am converting it to a RasterLayer temporarily (it will get switched back)
+  ## also save the original CRS since it gets coded slightly differently in raster
+  original_crs <- terra::crs(lyr)
   lyr <- raster::raster(lyr)
 
   rast_vals <-
@@ -69,8 +71,9 @@ future::plan() should be used to setup parallelization instead (see package vign
 
   if (parallel) future::plan("sequential")
 
-  # convert back to SpatRast
+  # convert back to SpatRast and reassign original crs
   lyr <- terra::rast(lyr)
+  terra::crs(lyr) <- original_crs
 
   # format resulting raster values
   result <- vals_to_lyr(lyr, rast_vals, stat)

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -143,11 +143,11 @@ resist_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
 #' distmat <- get_resdist(mini_coords, mini_lyr)
 #' }
 get_resdist <- function(coords, lyr, fact = 0, transitionFunction = mean, directions = 8, geoCorrection = TRUE, coords_only = FALSE, ncores = NULL, parallel = FALSE) {
+  # check lyr and coords
+  lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
+
   # convert lyr to raster
   if (!inherits(lyr, "RasterLayer")) lyr <- raster::raster(lyr)
-
-  # aggregate raster
-  if (fact != 0) lyr <- terra::aggregate(lyr, fact, fun = mean)
 
   # convert coords to dataframe and rename
   coords_df <- coords_to_df(coords)
@@ -202,7 +202,7 @@ get_resdist <- function(coords, lyr, fact = 0, transitionFunction = mean, direct
 coords_to_df <- function(coords) {
   if (inherits(coords, "SpatVector")) coords <- sf::st_as_sf(coords)
   if (is.matrix(coords)) coords <- data.frame(coords)
-  if (inherits(coords, "sf")) coords <- as.data.frame(sf::as_Spatial(coords))
+  if (inherits(coords, "sf")) coords <- data.frame(sf::st_coordinates(coords))
   colnames(coords) <- c("x", "y")
   return(coords)
 }

--- a/sse.Rmd
+++ b/sse.Rmd
@@ -101,7 +101,7 @@ plot(lyr)
 trSurface <- gdistance::transition(aggregate(pred, 20), transitionFunction = mean, directions = 8)
 trSurface <- gdistance::geoCorrection(trSurface, type = "c", scl = FALSE)
 
-distmat <- get_resdist(lotr_coords, cond.r = pred, ncores= 25)
+distmat <- get_resdist(coords, cond.r = pred, ncores= 25)
 write.csv(distmat, "distmat30.csv")
 ```
 

--- a/tests/testthat/test_preview_gd.R
+++ b/tests/testthat/test_preview_gd.R
@@ -126,7 +126,7 @@ test_that("preview_gd works for circle method with all different coordinate type
 test_that("preview_gd works for resist method", {
   load_mini_ex(quiet = TRUE)
   capture_warnings(distmat <- get_resdist(mini_coords, mini_lyr, fact = 5, ncores = 2))
-  pw <- preview_gd(
+  capture_warnings(pw <- preview_gd(
     mini_lyr,
     mini_coords,
     method = "resist",
@@ -136,7 +136,7 @@ test_that("preview_gd works for resist method", {
     sample_count = TRUE,
     min_n = 2,
     ncores = 2
-  )
+  ))
 
   expect_equal(terra::nlyr(pw), 1)
 })


### PR DESCRIPTION
Minor changes to resist_gd() and general_gd()

resist_gd() changes:
- switch from as_Spatial() which will result in an error if the sf object has other non-coordinate attributes to st_coordinates() which just returns the coords
- add layer check to get_resdist so that the CRS are checked and aggregation happens in one step

general_gd() changes:
- when the terra rasters were converted to raster rasters the CRS ended up being coded slightly differently such that the original layer and the final layer have different CRS. I have now saved the original CRS and reassigned it again at the very end.