### PR TITLE
Patch and test *_general() functions

### DIFF
--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -117,6 +117,7 @@ circle_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
     rarify_alleles = rarify_alleles,
     parallel = parallel,
     ncores = ncores,
+    ...
   )
 
   return(results)

--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -119,7 +119,8 @@ circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
     rarify_alleles = rarify_alleles,
     sig = sig,
     parallel = parallel,
-    ncores = ncores
+    ncores = ncores,
+    ...
   )
 
   return(results)

--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -22,7 +22,7 @@
 circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fact = 0,
                       rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                       fun = mean, L = "nvariants", rarify_alleles = TRUE, sig = 0.05,
-                      parallel = FALSE, ncores = NULL, ...) {
+                      parallel = FALSE, ncores = NULL) {
   # convert lyr to SpatRaster
   if (!inherits(lyr, "SpatRaster")) lyr <- terra::rast(lyr)
 
@@ -54,8 +54,7 @@ circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       rarify_alleles = rarify_alleles,
       sig = sig,
       parallel = parallel,
-      ncores = ncores,
-      ...
+      ncores = ncores
     )
 
   return(results)
@@ -96,6 +95,7 @@ circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
                            rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                            fun = mean, L = NULL, rarify_alleles = TRUE, sig = 0.05,
                            parallel = FALSE, ncores = NULL, ...) {
+
   # check and aggregate layer and coords  (only lyr is returned)
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
 
@@ -119,8 +119,7 @@ circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
     rarify_alleles = rarify_alleles,
     sig = sig,
     parallel = parallel,
-    ncores = ncores,
-    ...
+    ncores = ncores
   )
 
   return(results)

--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -22,7 +22,7 @@
 circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fact = 0,
                       rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                       fun = mean, L = "nvariants", rarify_alleles = TRUE,
-                      parallel = FALSE, ncores = NULL) {
+                      parallel = FALSE, ncores = NULL, ...) {
   # convert lyr to SpatRaster
   if (!inherits(lyr, "SpatRaster")) lyr <- terra::rast(lyr)
 
@@ -53,7 +53,8 @@ circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       L = L,
       rarify_alleles = rarify_alleles,
       parallel = parallel,
-      ncores = ncores
+      ncores = ncores,
+      ...
     )
 
   return(results)

--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -90,7 +90,7 @@ circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
 #' @return SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell
 #'
 #' @export
-circle_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
+circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact = 0,
                            rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                            fun = mean, L = NULL, rarify_alleles = TRUE,
                            parallel = FALSE, ncores = NULL, ...) {

--- a/R/circle_gd.R
+++ b/R/circle_gd.R
@@ -21,7 +21,7 @@
 #' }
 circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fact = 0,
                       rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                      fun = mean, L = "nvariants", rarify_alleles = TRUE,
+                      fun = mean, L = "nvariants", rarify_alleles = TRUE, sig = 0.05,
                       parallel = FALSE, ncores = NULL, ...) {
   # convert lyr to SpatRaster
   if (!inherits(lyr, "SpatRaster")) lyr <- terra::rast(lyr)
@@ -52,6 +52,7 @@ circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       fun = fun,
       L = L,
       rarify_alleles = rarify_alleles,
+      sig = sig,
       parallel = parallel,
       ncores = ncores,
       ...
@@ -93,7 +94,7 @@ circle_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
 #' @export
 circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact = 0,
                            rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                           fun = mean, L = NULL, rarify_alleles = TRUE,
+                           fun = mean, L = NULL, rarify_alleles = TRUE, sig = 0.05,
                            parallel = FALSE, ncores = NULL, ...) {
   # check and aggregate layer and coords  (only lyr is returned)
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
@@ -116,6 +117,7 @@ circle_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
     fun = fun,
     L = L,
     rarify_alleles = rarify_alleles,
+    sig = sig,
     parallel = parallel,
     ncores = ncores,
     ...

--- a/R/dist_gd.R
+++ b/R/dist_gd.R
@@ -8,7 +8,8 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
                     maxdist, distmat,
                     rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                     fun = mean, L = NULL, rarify_alleles = TRUE,
-                    parallel = FALSE, ncores = NULL) {
+                    parallel = FALSE, ncores = NULL, ...) {
+
   # convert maxdist to SpatRaster
   if (!is.numeric(maxdist)) {
     if (!inherits(maxdist, "SpatRaster")) maxdist <- terra::rast(maxdist)
@@ -34,7 +35,8 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
         L = L,
         rarify_alleles = rarify_alleles,
         parallel = parallel,
-        ncores = ncores
+        ncores = ncores,
+        ...
       )
     )
 
@@ -55,7 +57,7 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
 dist_gd_stats <- function(gen, coords, lyr, stat, maxdist, distmat,
                           rarify, rarify_n, rarify_nit, min_n,
                           fun, L, rarify_alleles,
-                          parallel, ncores) {
+                          parallel, ncores, ...) {
   # check that the input file is a vcfR or a path to a vcf object
   vcf <- vcf_check(gen)
 
@@ -82,6 +84,7 @@ dist_gd_stats <- function(gen, coords, lyr, stat, maxdist, distmat,
     rarify_alleles = rarify_alleles,
     parallel = parallel,
     ncores = ncores,
+    ...
   )
 
   return(results)
@@ -107,12 +110,24 @@ dist_general <- function(x, coords, lyr, stat, maxdist, distmat,
 
   # run general moving window
   result <- run_general(
-    x = x, lyr = lyr, coords = coords,
-    distmat = distmat, maxdist = maxdist,
+    x = x,
+    lyr = lyr,
+    coords = coords,
+    coord_cells = NULL,
+    nmat = NULL,
+    distmat = distmat,
+    maxdist = maxdist,
     stat = stat,
-    rarify = rarify, rarify_n = rarify_n, rarify_nit = rarify_nit,
-    min_n = min_n, fun = fun, L = L, rarify_alleles = rarify_alleles,
-    parallel = parallel, ncores = ncores, ...
+    rarify = rarify,
+    rarify_n = rarify_n,
+    rarify_nit = rarify_nit,
+    min_n = min_n,
+    fun = fun,
+    L = L,
+    rarify_alleles = rarify_alleles,
+    parallel = parallel,
+    ncores = ncores,
+    ...
   )
 
   return(result)

--- a/R/dist_gd.R
+++ b/R/dist_gd.R
@@ -7,7 +7,7 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
                     fact = fact,
                     maxdist, distmat,
                     rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                    fun = mean, L = NULL, rarify_alleles = TRUE,
+                    fun = mean, L = NULL, rarify_alleles = TRUE, sig = 0.05,
                     parallel = FALSE, ncores = NULL, ...) {
 
   # convert maxdist to SpatRaster
@@ -34,6 +34,7 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
         fun = fun,
         L = L,
         rarify_alleles = rarify_alleles,
+        sig = sig,
         parallel = parallel,
         ncores = ncores,
         ...
@@ -56,7 +57,7 @@ dist_gd <- function(gen, coords, lyr, stat = "pi",
 #' @noRd
 dist_gd_stats <- function(gen, coords, lyr, stat, maxdist, distmat,
                           rarify, rarify_n, rarify_nit, min_n,
-                          fun, L, rarify_alleles,
+                          fun, L, rarify_alleles, sig,
                           parallel, ncores, ...) {
   # check that the input file is a vcfR or a path to a vcf object
   vcf <- vcf_check(gen)
@@ -82,6 +83,7 @@ dist_gd_stats <- function(gen, coords, lyr, stat, maxdist, distmat,
     fun = fun,
     L = L,
     rarify_alleles = rarify_alleles,
+    sig = sig,
     parallel = parallel,
     ncores = ncores,
     ...
@@ -102,7 +104,7 @@ dist_gd_stats <- function(gen, coords, lyr, stat, maxdist, distmat,
 #' @noRd
 dist_general <- function(x, coords, lyr, stat, maxdist, distmat,
                          rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                         fun = mean, L = NULL, rarify_alleles = TRUE,
+                         fun = mean, L = NULL, rarify_alleles = TRUE, sig = 0.05,
                          parallel = FALSE, ncores = NULL, ...) {
   # check lyr and distmat
   lyr <- layer_coords_check(lyr, coords)
@@ -125,6 +127,7 @@ dist_general <- function(x, coords, lyr, stat, maxdist, distmat,
     fun = fun,
     L = L,
     rarify_alleles = rarify_alleles,
+    sig = sig,
     parallel = parallel,
     ncores = ncores,
     ...

--- a/R/dist_gd.R
+++ b/R/dist_gd.R
@@ -112,7 +112,7 @@ dist_general <- function(x, coords, lyr, stat, maxdist, distmat,
     stat = stat,
     rarify = rarify, rarify_n = rarify_n, rarify_nit = rarify_nit,
     min_n = min_n, fun = fun, L = L, rarify_alleles = rarify_alleles,
-    parallel = parallel, ncores = ncores
+    parallel = parallel, ncores = ncores, ...
   )
 
   return(result)

--- a/R/general_gd.R
+++ b/R/general_gd.R
@@ -29,8 +29,10 @@ future::plan() should be used to setup parallelization instead (see package vign
   stat_function <- return_stat(stat = stat, ...)
 
   # check that coords and x align and reformat data, if necessary
-  # note: list2env adds the new, corrected x and coords back to the environment
-  list2env(check_data(x, coords = coords, distmat = distmat), envir = environment())
+  corrected_data <- check_data(x, coords = coords, distmat = distmat)
+  x <- corrected_data$x
+  coords <- corrected_data$coords
+  distmat <- corrected_data$distmat
 
   # transpose distmat so that the rows are the landscape cells
   if (!is.null(distmat)) distmat <- t(distmat)

--- a/R/general_gd.R
+++ b/R/general_gd.R
@@ -6,7 +6,7 @@
 run_general <- function(x, lyr, coords,
                         coord_cells = NULL, nmat = NULL,
                         distmat = NULL, maxdist = NULL,
-                        stat, rarify, rarify_n, rarify_nit, min_n, fun, L, rarify_alleles,
+                        stat, rarify, rarify_n, rarify_nit, min_n, fun, L, rarify_alleles, sig,
                         parallel = parallel, ncores = ncores, ...) {
 
   # deprecation warning for parallel/ncores
@@ -26,7 +26,7 @@ future::plan() should be used to setup parallelization instead (see package vign
   if (is.character(stat) & !is.null(L)) if (stat == "pi" & L == "nvariants") L <- ncol(x)
 
   # Get function to calculate the desired statistic
-  stat_function <- return_stat(stat, ...)
+  stat_function <- return_stat(stat = stat, ...)
 
   # check that coords and x align and reformat data, if necessary
   # note: list2env adds the new, corrected x and coords back to the environment
@@ -60,7 +60,8 @@ future::plan() should be used to setup parallelization instead (see package vign
         min_n = min_n,
         fun = fun,
         L = L,
-        rarify_alleles = rarify_alleles
+        rarify_alleles = rarify_alleles,
+        sig = sig
       ),
       .options = furrr::furrr_options(
         seed = TRUE,
@@ -92,7 +93,7 @@ window_helper <- function(i, x, lyr,
                           distmat = NULL, maxdist = NULL,
                           stat_function,
                           rarify, rarify_n, rarify_nit, min_n,
-                          fun, L, rarify_alleles) {
+                          fun, L, rarify_alleles, sig) {
   # if rarify = TRUE and rarify_n isn't specified, rarify_n = min_n (i.e. rarify_n defaults to min_n)
   if (is.null(rarify_n)) rarify_n <- min_n
 
@@ -113,9 +114,9 @@ window_helper <- function(i, x, lyr,
   if (length(sub) < min_n) {
     gd <- NA
   } else if (rarify) {
-    gd <- rarify_helper(x, sub, rarify_n, rarify_nit, stat_function, fun, L = L, rarify_alleles = rarify_alleles)
+    gd <- rarify_helper(x, sub, rarify_n, rarify_nit, stat_function, fun, L = L, rarify_alleles = rarify_alleles, sig = sig)
   } else {
-    gd <- sample_gd(x, sub, stat_function, L = L, rarify_alleles = rarify_alleles)
+    gd <- sample_gd(x, sub, stat_function, L = L, rarify_alleles = rarify_alleles, sig = sig)
   }
 
   # count the number of samples in the window
@@ -142,7 +143,7 @@ window_helper <- function(i, x, lyr,
 #'
 #' @noRd
 rarify_helper <- function(x, sub, rarify_n, rarify_nit, stat_function,
-                          fun, L, rarify_alleles) {
+                          fun, L, rarify_alleles, sig) {
   # if number of samples is less than rarify_n, assign the value NA
   if (length(sub) < rarify_n) {
     gd <- NA
@@ -150,12 +151,12 @@ rarify_helper <- function(x, sub, rarify_n, rarify_nit, stat_function,
 
   # if number of samples is greater than rarify_n, rarify
   if (length(sub) > rarify_n) {
-    gd <- rarify_gd(x, sub, rarify_nit = rarify_nit, rarify_n = rarify_n, stat_function = stat_function, fun = fun, L = L, rarify_alleles = rarify_alleles)
+    gd <- rarify_gd(x, sub, rarify_nit = rarify_nit, rarify_n = rarify_n, stat_function = stat_function, fun = fun, L = L, rarify_alleles = rarify_alleles, sig = sig)
   }
 
   # if the number of samples is equal to rarify_n, calculate stat
   if (length(sub) == rarify_n) {
-    gd <- sample_gd(x, sub, stat_function, L = L, rarify_alleles = rarify_alleles)
+    gd <- sample_gd(x, sub, stat_function, L = L, rarify_alleles = rarify_alleles, sig = sig)
   }
 
   return(gd)
@@ -170,7 +171,7 @@ rarify_helper <- function(x, sub, rarify_n, rarify_nit, stat_function,
 #'
 #' @noRd
 rarify_gd <- function(x, sub, rarify_nit, rarify_n, stat_function,
-                      fun, L, rarify_alleles) {
+                      fun, L, rarify_alleles, sig) {
   # check to make sure sub is greater than rarify_n
   if (!(length(sub) > rarify_n)) {
     stop("rarify_n is less than the number of samples provided")
@@ -193,7 +194,7 @@ rarify_gd <- function(x, sub, rarify_nit, rarify_n, stat_function,
   # get all possible combos (rows are unique combos)
   # for each of the possible combos get gendiv stat
   cmb_ls <- as.list(data.frame(cmb))
-  gdrar <- purrr::map(cmb_ls, \(sub) sample_gd(x = x, sub = sub, stat_function = stat_function, L = L, rarify_alleles = rarify_alleles))
+  gdrar <- purrr::map(cmb_ls, \(sub) sample_gd(x = x, sub = sub, stat_function = stat_function, L = L, rarify_alleles = rarify_alleles, sig = sig))
 
   # summarize rarefaction results
   gd <- purrr::list_transpose(gdrar) %>% purrr::map_dbl(fun, na.rm = TRUE)
@@ -207,13 +208,19 @@ rarify_gd <- function(x, sub, rarify_nit, rarify_n, stat_function,
 #' @return mean allelic richness of a subsample
 #'
 #' @noRd
-sample_gd <- function(x, sub, stat_function, L, rarify_alleles) {
+sample_gd <- function(x, sub, stat_function, L, rarify_alleles, sig) {
   if (isTRUE(all.equal(stat_function, calc_mean_biar))) {
-    return(stat_function(x[sub, ], rarify_alleles))
+    return(stat_function(x[sub, ], rarify_alleles = rarify_alleles))
   }
+
   if (isTRUE(all.equal(stat_function, calc_pi))) {
-    return(stat_function(x[sub, ], L))
+    return(stat_function(x[sub, ], L = L))
   }
+
+  if (isTRUE(all.equal(stat_function, calc_prop_hwe))) {
+    return(stat_function(x[sub, ], sig = sig))
+  }
+
   return(stat_function(x[sub, ]))
 }
 

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -116,6 +116,7 @@ resist_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
     rarify_alleles = rarify_alleles,
     parallel = parallel,
     ncores = ncores,
+    ...
   )
 
   return(results)

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -25,7 +25,7 @@
 #' }
 resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fact = 0,
                       rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                      fun = mean, L = "nvariants", rarify_alleles = TRUE,
+                      fun = mean, L = "nvariants", rarify_alleles = TRUE, sig = 0.05,
                       transitionFunction = mean, directions = 8, geoCorrection = TRUE,
                       parallel = FALSE, ncores = NULL, ...) {
   # check and aggregate layer and coords  (only lyr is returned)
@@ -51,6 +51,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       fun = fun,
       L = L,
       rarify_alleles = rarify_alleles,
+      sig = sig,
       parallel = parallel,
       ncores = ncores,
       ...
@@ -91,7 +92,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
 #' @export
 resist_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact = 0,
                            rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
-                           fun = mean, L = NULL, rarify_alleles = TRUE,
+                           fun = mean, L = NULL, rarify_alleles = TRUE, sig = 0.05,
                            transitionFunction = mean, directions = 8, geoCorrection = TRUE,
                            parallel = FALSE, ncores = NULL, ...) {
 
@@ -128,6 +129,7 @@ resist_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
     fun = fun,
     L = L,
     rarify_alleles = rarify_alleles,
+    sig = sig,
     parallel = parallel,
     ncores = ncores,
     ...

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -88,7 +88,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
 #' @return SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell
 #'
 #' @export
-resist_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
+resist_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact = 0,
                            rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                            fun = mean, L = NULL, rarify_alleles = TRUE,
                            transitionFunction = mean, directions = 8, geoCorrection = TRUE,
@@ -97,7 +97,19 @@ resist_general <- function(x, coords, lyr, maxdist, distmat, stat, fact = 0,
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
 
   # make distmat
-  if (is.null(distmat)) suppressWarnings(distmat <- get_resdist(coords, lyr = lyr, transitionFunction = transitionFunction, directions = directions, geoCorrection = geoCorrection, parallel = parallel, ncores = ncores))
+  if (is.null(distmat))
+    suppressWarnings(
+      distmat <-
+        get_resdist(
+          coords,
+          lyr = lyr,
+          transitionFunction = transitionFunction,
+          directions = directions,
+          geoCorrection = geoCorrection,
+          parallel = parallel,
+          ncores = ncores
+        )
+    )
 
   # run general resist
   results <- dist_general(

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -28,6 +28,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
                       fun = mean, L = "nvariants", rarify_alleles = TRUE, sig = 0.05,
                       transitionFunction = mean, directions = 8, geoCorrection = TRUE,
                       parallel = FALSE, ncores = NULL, ...) {
+
   # check and aggregate layer and coords  (only lyr is returned)
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
 
@@ -53,8 +54,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       rarify_alleles = rarify_alleles,
       sig = sig,
       parallel = parallel,
-      ncores = ncores,
-      ...
+      ncores = ncores
     )
 
   return(results)

--- a/R/resist_gd.R
+++ b/R/resist_gd.R
@@ -27,7 +27,7 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
                       rarify = FALSE, rarify_n = 2, rarify_nit = 5, min_n = 2,
                       fun = mean, L = "nvariants", rarify_alleles = TRUE,
                       transitionFunction = mean, directions = 8, geoCorrection = TRUE,
-                      parallel = FALSE, ncores = NULL) {
+                      parallel = FALSE, ncores = NULL, ...) {
   # check and aggregate layer and coords  (only lyr is returned)
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
 
@@ -52,7 +52,8 @@ resist_gd <- function(gen, coords, lyr, maxdist, distmat = NULL, stat = "pi", fa
       L = L,
       rarify_alleles = rarify_alleles,
       parallel = parallel,
-      ncores = ncores
+      ncores = ncores,
+      ...
     )
 
   return(results)
@@ -93,6 +94,7 @@ resist_general <- function(x, coords, lyr, maxdist, distmat = NULL, stat, fact =
                            fun = mean, L = NULL, rarify_alleles = TRUE,
                            transitionFunction = mean, directions = 8, geoCorrection = TRUE,
                            parallel = FALSE, ncores = NULL, ...) {
+
   # check and aggregate layer and coords  (only lyr is returned)
   lyr <- layer_coords_check(lyr = lyr, coords = coords, fact = fact)
 

--- a/R/stats_gd.R
+++ b/R/stats_gd.R
@@ -200,15 +200,16 @@ calc_prop_hwe <- function(genind, sig = 0.05) {
 #' Calculate basic stats using \link[hierfstat]{basic.stats}
 #'
 #' @param hf hierfstat object
+#' @param ... additional arguments to pass to basic stats
 #'
 #' @return vector of overall stats produced by \link[hierfstat]{basic.stats}
 #'
 #' @noRd
-calc_mean_basic_stats <- function(hf) {
+calc_mean_basic_stats <- function(hf, ...) {
   # reassign pop so that if the levels present in the original factor change you don't get an error
   # e.g., if original pop was 1 & 2, but a subset only has 2, you will get an error
   hf$pop <- as.numeric(as.character(hf$pop))
-  hfstat <- hierfstat::basic.stats(hf)
+  hfstat <- hierfstat::basic.stats(hf, ...)
   mean_stats <- hfstat$overall
 
   # drop stats that aren't meaningful if there is only one populatoin
@@ -233,27 +234,27 @@ return_stat <- function(stat, ...) {
   }
 
   if (stat == "pi") {
-    return(calc_pi)
+    return(purrr::partial(calc_pi, ...))
   }
 
   if (stat == "biallelic_richness") {
-    return(calc_mean_biar)
+    return(purrr::partial(calc_mean_biar, ...))
   }
 
   if (stat == "allelic_richness") {
-    return(calc_mean_ar)
+    return(purrr::partial(calc_mean_ar, ...))
   }
 
   if (stat == "Ho") {
-    return(calc_mean_het)
+    return(purrr::partial(calc_mean_het, ...))
   }
 
   if (stat == "hwe") {
-    return(calc_prop_hwe)
+    return(purrr::partial(calc_prop_hwe, ...))
   }
 
   if (stat == "basic_stats") {
-    return(calc_mean_basic_stats)
+    return(purrr::partial(calc_mean_basic_stats, ...))
   }
 
   stop(paste(stat, "is an invalid argument for stat"))

--- a/R/stats_gd.R
+++ b/R/stats_gd.R
@@ -250,7 +250,7 @@ return_stat <- function(stat, ...) {
   }
 
   if (stat == "hwe") {
-    return(purrr::partial(calc_prop_hwe, ...))
+    return(calc_prop_hwe)
   }
 
   if (stat == "basic_stats") {

--- a/R/stats_gd.R
+++ b/R/stats_gd.R
@@ -205,11 +205,11 @@ calc_prop_hwe <- function(genind, sig = 0.05) {
 #' @return vector of overall stats produced by \link[hierfstat]{basic.stats}
 #'
 #' @noRd
-calc_mean_basic_stats <- function(hf, ...) {
+calc_mean_basic_stats <- function(hf) {
   # reassign pop so that if the levels present in the original factor change you don't get an error
   # e.g., if original pop was 1 & 2, but a subset only has 2, you will get an error
   hf$pop <- as.numeric(as.character(hf$pop))
-  hfstat <- hierfstat::basic.stats(hf, ...)
+  hfstat <- hierfstat::basic.stats(hf)
   mean_stats <- hfstat$overall
 
   # drop stats that aren't meaningful if there is only one populatoin
@@ -234,19 +234,19 @@ return_stat <- function(stat, ...) {
   }
 
   if (stat == "pi") {
-    return(purrr::partial(calc_pi, ...))
+    return(calc_pi)
   }
 
   if (stat == "biallelic_richness") {
-    return(purrr::partial(calc_mean_biar, ...))
+    return(calc_mean_biar)
   }
 
   if (stat == "allelic_richness") {
-    return(purrr::partial(calc_mean_ar, ...))
+    return(calc_mean_ar)
   }
 
   if (stat == "Ho") {
-    return(purrr::partial(calc_mean_het, ...))
+    return(calc_mean_het)
   }
 
   if (stat == "hwe") {
@@ -254,7 +254,7 @@ return_stat <- function(stat, ...) {
   }
 
   if (stat == "basic_stats") {
-    return(purrr::partial(calc_mean_basic_stats, ...))
+    return(calc_mean_basic_stats)
   }
 
   stop(paste(stat, "is an invalid argument for stat"))

--- a/R/window_gd.R
+++ b/R/window_gd.R
@@ -19,7 +19,7 @@
 #' @param parallel whether to parallelize the function (defaults to FALSE; **deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)**)
 #' @param ncores if parallel = TRUE, number of cores to use for parallelization (defaults to total available number of cores minus 1; **deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)**)
 #' @param crop_edges whether to remove cells on the edge of the raster where the window is incomplete (defaults to FALSE)
-#' @param ... additional arguments to pass to the `stat` function (e.g. if `stat = hwe`, users may want to set `sig` to a different value)
+#' @param ... [deprecated] this was intended to be used to pass additional arguments to the `stat` function, however now formal arguments are used instead (see `L`, `rarify_alleles`, and `sig`). Passing additional arguments using `...` is still possible with the `*_general()` functions.
 #' @details
 #'
 #' Coordinates and rasters should be in a projected (planar) coordinate system such that raster cells are of equal sizes.
@@ -74,8 +74,7 @@ window_gd <- function(gen, coords, lyr, stat = "pi", wdim = 3, fact = 0,
         sig = sig,
         parallel = parallel,
         ncores = ncores,
-        crop_edges = crop_edges,
-        ...
+        crop_edges = crop_edges
       )
     )
 

--- a/R/window_gd.R
+++ b/R/window_gd.R
@@ -175,7 +175,7 @@ window_general <- function(x, coords, lyr, stat, wdim = 3, fact = 0,
     stat = stat,
     rarify = rarify, rarify_n = rarify_n, rarify_nit = rarify_nit,
     min_n = min_n, fun = fun, L = L, rarify_alleles = rarify_alleles,
-    parallel = parallel, ncores = ncores
+    parallel = parallel, ncores = ncores, ...
   )
 
   # crop resulting raster

--- a/R/window_gd.R
+++ b/R/window_gd.R
@@ -170,12 +170,24 @@ window_general <- function(x, coords, lyr, stat, wdim = 3, fact = 0,
 
   # run general moving window
   result <- run_general(
-    x = x, lyr = lyr, coords = coords,
-    coord_cells = coord_cells, nmat = nmat,
+    x = x,
+    lyr = lyr,
+    coords = coords,
+    coord_cells = coord_cells,
+    nmat = nmat,
+    distmat = NULL,
+    maxdist = NULL,
     stat = stat,
-    rarify = rarify, rarify_n = rarify_n, rarify_nit = rarify_nit,
-    min_n = min_n, fun = fun, L = L, rarify_alleles = rarify_alleles,
-    parallel = parallel, ncores = ncores, ...
+    rarify = rarify,
+    rarify_n = rarify_n,
+    rarify_nit = rarify_nit,
+    min_n = min_n,
+    fun = fun,
+    L = L,
+    rarify_alleles = rarify_alleles,
+    parallel = parallel,
+    ncores = ncores,
+    ...
   )
 
   # crop resulting raster

--- a/man/circle_gd.Rd
+++ b/man/circle_gd.Rd
@@ -20,7 +20,8 @@ circle_gd(
   L = "nvariants",
   rarify_alleles = TRUE,
   parallel = FALSE,
-  ncores = NULL
+  ncores = NULL,
+  ...
 )
 }
 \arguments{
@@ -56,6 +57,8 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 
 \item{ncores}{if parallel = TRUE, number of cores to use for parallelization (defaults to total available number of cores minus 1; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
+
+\item{...}{additional arguments to pass to the \code{stat} function (e.g. if \code{stat = hwe}, users may want to set \code{sig} to a different value)}
 }
 \value{
 SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell

--- a/man/circle_gd.Rd
+++ b/man/circle_gd.Rd
@@ -21,8 +21,7 @@ circle_gd(
   rarify_alleles = TRUE,
   sig = 0.05,
   parallel = FALSE,
-  ncores = NULL,
-  ...
+  ncores = NULL
 )
 }
 \arguments{
@@ -60,8 +59,6 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 
 \item{ncores}{if parallel = TRUE, number of cores to use for parallelization (defaults to total available number of cores minus 1; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
-
-\item{...}{additional arguments to pass to the \code{stat} function (e.g. if \code{stat = hwe}, users may want to set \code{sig} to a different value)}
 }
 \value{
 SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell

--- a/man/circle_gd.Rd
+++ b/man/circle_gd.Rd
@@ -19,6 +19,7 @@ circle_gd(
   fun = mean,
   L = "nvariants",
   rarify_alleles = TRUE,
+  sig = 0.05,
   parallel = FALSE,
   ncores = NULL,
   ...
@@ -50,9 +51,11 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 

--- a/man/circle_general.Rd
+++ b/man/circle_general.Rd
@@ -9,7 +9,7 @@ circle_general(
   coords,
   lyr,
   maxdist,
-  distmat,
+  distmat = NULL,
   stat,
   fact = 0,
   rarify = FALSE,

--- a/man/circle_general.Rd
+++ b/man/circle_general.Rd
@@ -19,6 +19,7 @@ circle_general(
   fun = mean,
   L = NULL,
   rarify_alleles = TRUE,
+  sig = 0.05,
   parallel = FALSE,
   ncores = NULL,
   ...
@@ -50,9 +51,11 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 

--- a/man/resist_gd.Rd
+++ b/man/resist_gd.Rd
@@ -19,6 +19,7 @@ resist_gd(
   fun = mean,
   L = "nvariants",
   rarify_alleles = TRUE,
+  sig = 0.05,
   transitionFunction = mean,
   directions = 8,
   geoCorrection = TRUE,
@@ -53,9 +54,11 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{transitionFunction}{function to calculate transition values from grid values (defaults to mean)}
 

--- a/man/resist_gd.Rd
+++ b/man/resist_gd.Rd
@@ -70,7 +70,7 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 
 \item{ncores}{if parallel = TRUE, number of cores to use for parallelization (defaults to total available number of cores minus 1; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 
-\item{...}{additional arguments to pass to the \code{stat} function (e.g. if \code{stat = hwe}, users may want to set \code{sig} to a different value)}
+\item{...}{\link{deprecated} this was intended to be used to pass additional arguments to the \code{stat} function, however now formal arguments are used instead (see \code{L}, \code{rarify_alleles}, and \code{sig}). Passing additional arguments using \code{...} is still possible with the \verb{*_general()} functions.}
 }
 \value{
 SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell

--- a/man/resist_gd.Rd
+++ b/man/resist_gd.Rd
@@ -23,7 +23,8 @@ resist_gd(
   directions = 8,
   geoCorrection = TRUE,
   parallel = FALSE,
-  ncores = NULL
+  ncores = NULL,
+  ...
 )
 }
 \arguments{
@@ -65,6 +66,8 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 
 \item{ncores}{if parallel = TRUE, number of cores to use for parallelization (defaults to total available number of cores minus 1; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
+
+\item{...}{additional arguments to pass to the \code{stat} function (e.g. if \code{stat = hwe}, users may want to set \code{sig} to a different value)}
 }
 \value{
 SpatRaster that includes a raster layer of genetic diversity and a raster layer of the number of samples within the window for each cell

--- a/man/resist_general.Rd
+++ b/man/resist_general.Rd
@@ -9,7 +9,7 @@ resist_general(
   coords,
   lyr,
   maxdist,
-  distmat,
+  distmat = NULL,
   stat,
   fact = 0,
   rarify = FALSE,

--- a/man/resist_general.Rd
+++ b/man/resist_general.Rd
@@ -19,6 +19,7 @@ resist_general(
   fun = mean,
   L = NULL,
   rarify_alleles = TRUE,
+  sig = 0.05,
   transitionFunction = mean,
   directions = 8,
   geoCorrection = TRUE,
@@ -53,9 +54,11 @@ Can either be (1) a single numeric value or (2) a SpatRaster where each pixel is
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{transitionFunction}{function to calculate transition values from grid values (defaults to mean)}
 

--- a/man/window_gd.Rd
+++ b/man/window_gd.Rd
@@ -18,6 +18,7 @@ window_gd(
   fun = mean,
   L = "nvariants",
   rarify_alleles = TRUE,
+  sig = 0.05,
   parallel = FALSE,
   ncores = NULL,
   crop_edges = FALSE,
@@ -47,9 +48,11 @@ window_gd(
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 

--- a/man/window_gd.Rd
+++ b/man/window_gd.Rd
@@ -60,7 +60,7 @@ window_gd(
 
 \item{crop_edges}{whether to remove cells on the edge of the raster where the window is incomplete (defaults to FALSE)}
 
-\item{...}{additional arguments to pass to the \code{stat} function (e.g. if \code{stat = hwe}, users may want to set \code{sig} to a different value)}
+\item{...}{\link{deprecated} this was intended to be used to pass additional arguments to the \code{stat} function, however now formal arguments are used instead (see \code{L}, \code{rarify_alleles}, and \code{sig}). Passing additional arguments using \code{...} is still possible with the \verb{*_general()} functions.}
 }
 \value{
 SpatRaster that includes raster layers of genetic diversity and a raster layer of the number of samples within the window for each cell

--- a/man/window_general.Rd
+++ b/man/window_general.Rd
@@ -18,6 +18,7 @@ window_general(
   fun = mean,
   L = "nvariants",
   rarify_alleles = TRUE,
+  sig = 0.05,
   parallel = FALSE,
   ncores = NULL,
   crop_edges = FALSE,
@@ -47,9 +48,11 @@ window_general(
 
 \item{fun}{function to use to summarize rarefaction results (defaults to mean, must take \code{na.rm = TRUE} as an argument)}
 
-\item{L}{for calculating pi, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
+\item{L}{for calculating \code{"pi"}, L argument in \link[hierfstat]{pi.dosage} function. Return the average nucleotide diversity per nucleotide given the length L of the sequence. The wingen default is L = "nvariants" which sets L to the number of variants in the VCF. If L = NULL, returns the sum over SNPs of nucleotide diversity (\emph{note:} L = NULL is the \link[hierfstat]{pi.dosage} default which wingen does not use)}
 
 \item{rarify_alleles}{for calculating \code{"biallelic_richness"}, whether to perform rarefaction of allele counts as in \link[hierfstat]{allelic.richness} (defaults to TRUE)}
+
+\item{sig}{for calculating \code{"hwe"}, significance threshold (i.e., alpha level) to use for hardy-weinberg equilibrium tests (defaults to 0.05)}
 
 \item{parallel}{whether to parallelize the function (defaults to FALSE; \strong{deprecated as of 2.0.1: \link[future]{plan} should be used to setup parallelization instead (see package vignette)})}
 

--- a/tests/testthat/test_circle_gd.R
+++ b/tests/testthat/test_circle_gd.R
@@ -27,18 +27,30 @@ test_that("circle_gd returns expected output", {
   capture_warnings(wp <- circle_general(vcf_to_dosage(mini_vcf_NA), maxdist = mini_lyr, distmat = distmat, mini_coords, mini_lyr, stat = "pi", rarify = FALSE))
 
   # examples with custom functions
-  toy <- vcf_to_dosage(mini_vcf_NA)
-  # test on vector
-  capture_warnings(wm <- circle_general(toy[, 1], mini_coords, mini_lyr, maxdist = 10, distmat = distmat, stat = mean, na.rm = TRUE))
-  # test on matrix
-  capture_warnings(wm <- circle_general(toy, mini_coords, mini_lyr, maxdist = 10, distmat = distmat, stat = mean, na.rm = TRUE))
-  # test custom functions
-  foo <- function(x) var(apply(x, 2, var, na.rm = TRUE), na.rm = TRUE)
-  capture_warnings(wm <- circle_general(toy, mini_coords, mini_lyr, maxdist = 10, distmat = distmat, stat = foo))
-  foo <- function(x, na.rm = TRUE) var(apply(x, 2, var))
-  capture_warnings(wm <- circle_general(toy, mini_coords, mini_lyr, maxdist = 10, distmat = distmat, stat = foo, na.rm = TRUE))
-  foo <- function(x, na.rm = TRUE, silly = 2) sd(apply(x, 2, var)) * silly
-  capture_warnings(wm <- circle_general(toy, mini_coords, mini_lyr, maxdist = 10, distmat = distmat, stat = foo, na.rm = TRUE, silly = 3))
+  toy <- vcf_to_dosage(mini_vcf_NA)*0 + 1
+  # check if additional custom arguments provided work
+  foo <- function(x, silly) sum(x * silly, na.rm = TRUE)
+  capture_warnings(cg_1 <-
+                     circle_general(
+                       toy[, 3],
+                       mini_coords,
+                       mini_lyr,
+                       stat = foo,
+                       maxdist = 50,
+                       silly = 2
+                     )[[1]])
+
+  capture_warnings(cg_2 <-
+                     circle_general(
+                       toy[, 3],
+                       mini_coords,
+                       mini_lyr,
+                       stat = foo,
+                       maxdist = 50,
+                       silly = 1
+                     )[[1]])
+
+  expect_equal(terra::values(cg_1), terra::values(cg_2) * 2)
 })
 
 

--- a/tests/testthat/test_resist_gd.R
+++ b/tests/testthat/test_resist_gd.R
@@ -36,20 +36,34 @@ test_that("resist_gd returns expected output", {
 test_that("resist_general returns expected output", {
   load_mini_ex(quiet = TRUE)
 
-  capture_warnings(
-    rpi <- resist_general(
-      vcf_to_dosage(mini_vcf),
-      mini_coords,
-      mini_lyr,
-      stat = "pi",
-      rarify = FALSE,
-      maxdist = 50,
-      fact = 2,
-      distmat = NULL
-    )
-  )
+  # examples with custom functions
+  toy <- vcf_to_dosage(mini_vcf_NA)*0 + 1
+  toy[1:2, ] <- NA
 
-  expect_s4_class(rpi, "SpatRaster")
+  # check if additional custom arguments provided work
+  foo <- function(x, silly) sum(x * silly, na.rm = TRUE)
+
+  capture_warnings(rg_1 <-
+                     resist_general(
+                       toy[, 3],
+                       mini_coords,
+                       mini_lyr,
+                       stat = foo,
+                       maxdist = 100,
+                       silly = 2
+                     )[[1]])
+
+  capture_warnings(rg_2 <-
+                     resist_general(
+                       toy[, 3],
+                       mini_coords,
+                       mini_lyr,
+                       stat = foo,
+                       maxdist = 100,
+                       silly = 1
+                     )[[1]])
+
+  expect_equal(terra::values(rg_1), terra::values(rg_2) * 2)
 })
 
 

--- a/tests/testthat/test_window_gd.R
+++ b/tests/testthat/test_window_gd.R
@@ -366,7 +366,6 @@ test_that("custom functions with window general work", {
   expect_equal(terra::values(wm_1), terra::values(wm_2)*2)
 })
 
-
 test_that("get_adj works", {
   load_mini_ex(quiet = TRUE)
   data("mini_lyr")
@@ -450,8 +449,7 @@ test_that("CRS are handled correctly", {
 
   # mismatched CRS
   crs2_lyr <- terra::rast(mini_lyr)
-  terra::crs(crs2_lyr) <- "+init=epsg:4269 +proj=longlat +ellps=GRS80 +datum=NAD83
-  +no_defs +towgs84=0,0,0"
+  terra::crs(crs2_lyr) <- "+proj=longlat +ellps=GRS80 +datum=NAD83 +no_defs +towgs84=0,0,0"
   expect_error(window_gd(mini_vcf, crs_coords, crs2_lyr, rarify = FALSE), "CRS of the provided coordinates and raster do not match")
 })
 


### PR DESCRIPTION
Resolves two issues:
1. Additional arguments for custom functions were being ignored because of missing "..." in general functions
2. You had to provide a distmat to resist_general() and circle_general() instead of them being generated by default

The resolutions were:
1. (a) Change handling of "..." arguments. Now, ...  is only applicable for *_general() functions (this is the same as before, but before we said in the docs you could use ... for window/circle/resist_gd() functions when you couldn't)

1.  (b) A sig argument was added to set a alpha threshold for  HWE tests instead of passing sig as a ... argument. This is more consistent with how we handled L and rarify_alleles arguments for the other functions and it makes sense for this to be defined rather than arbitrarily passed as a .... argument 

2. distmat is now set to NULL in all cases